### PR TITLE
Check if user's directory does not exist before appending

### DIFF
--- a/etc/X11/Xsession.d/47x11-local_xdg_data_dir
+++ b/etc/X11/Xsession.d/47x11-local_xdg_data_dir
@@ -1,4 +1,6 @@
-# Add user's directory to XDG_DATA_DIRS
+# Add user's directory to XDG_DATA_DIRS if it does not already exist
 
-XDG_DATA_DIRS="$XDG_DATA_DIRS":$HOME/.local/share
-export XDG_DATA_DIRS
+if [[ ":$XDG_DATA_DIRS:" != *":$HOME/.local/share:"* ]]; then
+  XDG_DATA_DIRS="$XDG_DATA_DIRS":$HOME/.local/share
+  export XDG_DATA_DIRS
+fi


### PR DESCRIPTION
I noticed duplicate entries when searching for applications with Ilia and new duplicate entries were getting added each time that I logged out and logged back in. Inspecting `$XDG_DATA_DIRS` shows that a new copy of `$HOME/.local/share` was getting added each time. 

In this PR, we check if the directory already exists before appending it to `$XDG_DATA_DIRS`. I verified that new entries were no longer added after logging out and logging back in.