### PR TITLE
Remove old look comment declarations

### DIFF
--- a/usr/bin/regolith-look
+++ b/usr/bin/regolith-look
@@ -52,6 +52,9 @@ set_look() {
 
     # Unset any existing values
     if [ -f "$USER_XRESOURCE_OVERRIDE_FILE" ]; then
+	# remove existing declaration comments
+        sed -i '/^!regolith.look.path/d' "$USER_XRESOURCE_OVERRIDE_FILE"
+
         # disable existing declaration
         sed -i 's/^regolith.look.path/\!regolith.look.path/g' "$USER_XRESOURCE_OVERRIDE_FILE"
     fi


### PR DESCRIPTION
Fixes: https://github.com/regolith-linux/regolith-desktop/issues/658

removes existing comments that start `!regolith.look.path` to stop Xresources file getting filled with comments when you switch looks a lot.