### PR TITLE
Add Xsession file for setting XDG_DATA_DIR if empty

### DIFF
--- a/debian/regolith-session-flashback.install
+++ b/debian/regolith-session-flashback.install
@@ -3,3 +3,4 @@ usr/share/xsessions
 usr/share/applications
 usr/bin
 usr/lib/regolith
+etc/X11/Xsession.d

--- a/etc/X11/Xsession.d/55regolith-session
+++ b/etc/X11/Xsession.d/55regolith-session
@@ -1,0 +1,23 @@
+# If we are running the Regolith session, source ~/.config/regolith2/xsessionrc
+
+BASESTARTUP=${STARTUP%% *}
+BASESTARTUP=${BASESTARTUP##*/}
+if [ "$BASESTARTUP" = x-session-manager ]; then
+    BASESTARTUP=$(basename $(readlink /etc/alternatives/x-session-manager))
+fi
+case "$BASESTARTUP" in
+  regolith-session*)
+    REGOLITHRC=$HOME/.config/regolith2/xsessionrc
+    if [ -r "$REGOLITHRC" ]; then
+      . "$REGOLITHRC"
+    fi
+    # We prepend /usr/share/gnome since its defaults.list actually points
+    # to /etc so it is configurable.
+    if [ -z "$XDG_DATA_DIRS" ]; then
+      XDG_DATA_DIRS=/usr/share/gnome:/usr/local/share/:/usr/share/
+    elif [ -n "${XDG_DATA_DIRS##*/usr/share/gnome*}" ]; then
+      XDG_DATA_DIRS=/usr/share/gnome:"$XDG_DATA_DIRS"
+    fi
+    export XDG_DATA_DIRS
+    ;;
+esac


### PR DESCRIPTION
It seems like there has been a little history for `XDG_DATA_DIRS` and Regolith. Commit 4f6755964f4a399668c19a1020889a3c3d879c4e added support for loading `$HOME/.local/share` but was reverted for just the debian/bullseye branch in 4572d80f526e3013d24ca5516f6f3c325a03e810. I broke my session when trying to add it manually with Regolith 1.6, which was reproduced in <https://old.reddit.com/r/regolithlinux/comments/uw0zpy/regolith_20_beta_2_is_available_for_testing/i9xohzb/>. However, something seems to have changed in Regolith >=2.0 because my tinkering didn't break X11 anymore!

I have _only_ tested on Debian Bullseye and, while I don't think it would impact Ubuntu, I haven't confirmed that. The changes are based on `/etc/X11/Xsession.d/55gnome-session_gnomerc` from the `gnome-session-common` package, with the following changes:
* Do not source `$HOME/.gnomerc`
* Add `$HOME/.local/share` to the default `XDG_DATA_DIRS` if `XDG_DATA_DIRS` is empty

If these changes are satisfactory, they _may_ allow debian/bullseye to stop being a parallel branch and merge back into main. It may also deprecate [`47x11-local_xdg_data_dir`](https://github.com/regolith-linux/regolith-session/blob/ac6eb70b401beec8cc90c32fd901466ada8ded2f/etc/X11/Xsession.d/47x11-local_xdg_data_dir); I only kept the 55 ID prefix because that's what Gnome used.