### PR TITLE
sway-regolith rename, added additional dependencies to control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,7 @@ Architecture: any
 Depends: ${misc:Depends},
     clipman,
     dbus,
-    sway,
+    sway-regolith,
     swayidle,
     trawlcat,
     trawld,

--- a/debian/control
+++ b/debian/control
@@ -42,7 +42,7 @@ Depends: ${misc:Depends},
     trawldb,
     gnome-session-bin,
     wl-clipboard,
-    regolith-look-default
+    regolith-look-default-loader
     xwayland,
 Provides: regolith-desktop-session
 Conflicts: session-shortcuts

--- a/debian/control
+++ b/debian/control
@@ -40,8 +40,10 @@ Depends: ${misc:Depends},
     trawlcat,
     trawld,
     trawldb,
+    gnome-session-bin,
     wl-clipboard,
-    xwayland
+    regolith-look-default
+    xwayland,
 Provides: regolith-desktop-session
 Conflicts: session-shortcuts
 Description: Regolith customized SwayWM session

--- a/usr/bin/regolith-session-wayland
+++ b/usr/bin/regolith-session-wayland
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This script initializes Regolith Xresources and launches i3.
+# This script initializes Regolith Xresources and launches sway.
 
 set -Eeu -o pipefail
 source /usr/lib/regolith/regolith-session-common.sh
@@ -11,13 +11,12 @@ load_standard_trawlres
 load_regolith_trawlres
 
 # Register with gnome-session so that it does not kill the whole session thinking it is dead.
-# See https://zork.net/~st/jottings/gnome-i3.html for details
 if [ -n "$DESKTOP_AUTOSTART_ID" ]; then
     dbus-send --print-reply --session --dest=org.gnome.SessionManager "/org/gnome/SessionManager" org.gnome.SessionManager.RegisterClient "string:Regolith" "string:$DESKTOP_AUTOSTART_ID"
 fi
 
 echo "Regolith is launching sway with $SWAY_CONFIG_FILE"
-sway -c "$SWAY_CONFIG_FILE"
+sway-regolith -c "$SWAY_CONFIG_FILE"
 
 # Run user's post logout script if script. Post logout means that the wayland session has been terminated.
 if [ -f "$USER_POST_LOGOUT_SCRIPT_FILE" ] ; then

--- a/usr/share/applications/regolith-wayland.desktop
+++ b/usr/share/applications/regolith-wayland.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Type=Application
-Name=regolith-sway
+Name=regolith-wayland
 Comment=Productivity-focused desktop environment, Regolith
-Exec=regolith-session-sway
+Exec=regolith-session-wayland
 X-GNOME-WMName=Regolith
 X-GNOME-Autostart-Phase=WindowManager
 X-GNOME-Provides=windowmanager

--- a/usr/share/gnome-session/sessions/regolith-sway.session
+++ b/usr/share/gnome-session/sessions/regolith-sway.session
@@ -1,3 +1,0 @@
-[GNOME Session]
-Name=Regolith Sway
-RequiredComponents=org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;regolith-sway;

--- a/usr/share/gnome-session/sessions/regolith-wayland.session
+++ b/usr/share/gnome-session/sessions/regolith-wayland.session
@@ -1,0 +1,3 @@
+[GNOME Session]
+Name=Regolith Wayland
+RequiredComponents=org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;regolith-wayland;

--- a/usr/share/wayland-sessions/regolith-sway.desktop
+++ b/usr/share/wayland-sessions/regolith-sway.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Name=Regolith on Wayland
 Comment=Productivity focused desktop environment
-Exec=/usr/bin/gnome-session --builtin --session=regolith-sway
+Exec=/usr/bin/gnome-session --builtin --session=regolith-wayland
 Type=Application


### PR DESCRIPTION
# Changelog 
1. Use of `sway-regolith` instead of default version of sway. 
2. Renamed all occurrences of session name to `regolith wayland` as compared to `regolith sway`. This also includes file names. 
3. Added `regolith-look-default` and `gnome-session-bin` as dependencies.