### PR TITLE
Added regolith-session-common binary package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -44,8 +44,7 @@ Depends: ${misc:Depends},
     trawldb,
     wl-clipboard,
     xwayland
-Provides: regolith-desktop-session
 Conflicts: session-shortcuts
 Description: Regolith customized SwayWM session
- This package contains the desktop and xsession configuration
+ This package contains the desktop and wayland session configuration
  necessary to start a Regolith sway session.

--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Depends: ${misc:Depends},
     gnome-session-bin,
     mutter-common,
     regolith-i3-config,
+    regolith-session-common,
     x11-xserver-utils,
     regolith-look-default | regolith-look-2,
     xorg,
@@ -36,6 +37,7 @@ Depends: ${misc:Depends},
     clipman,
     dbus,
     gnome-session-bin,
+    regolith-session-common,
     regolith-look-default-loader,
     sway-regolith,
     swayidle,
@@ -48,3 +50,11 @@ Conflicts: session-shortcuts
 Description: Regolith customized SwayWM session
  This package contains the desktop and wayland session configuration
  necessary to start a Regolith sway session.
+
+Package: regolith-session-common
+Architecture: any
+Depends: ${misc:Depends},
+    regolith-resource-loader
+Conflicts: session-shortcuts
+Description: Regolith customized SwayWM session
+ This package contains common scripts required by regolith-session variants.

--- a/debian/regolith-session-common.install
+++ b/debian/regolith-session-common.install
@@ -1,0 +1,3 @@
+usr/bin/regolith-diagnostic
+usr/lib/regolith/regolith-session-common.sh
+usr/bin/regolith-look

--- a/debian/regolith-session-flashback.install
+++ b/debian/regolith-session-flashback.install
@@ -1,6 +1,6 @@
-usr/share/gnome-session/sessions
+usr/share/gnome-session/sessions/regolith.session
 usr/share/xsessions
-usr/share/applications
-usr/bin
-usr/lib/regolith
+usr/share/applications/regolith.desktop
+usr/bin/regolith-session
+usr/bin/regolith-session-init
 etc/X11/Xsession.d

--- a/debian/regolith-session-sway.install
+++ b/debian/regolith-session-sway.install
@@ -1,5 +1,5 @@
 usr/bin/regolith-session-wayland
-usr/bin/regolith-diagnostic
-usr/lib/regolith/regolith-session-common.sh
+usr/share/gnome-session/sessions/regolith-wayland.session
 usr/share/wayland-sessions
+usr/share/applications/regolith-wayland.desktop
 etc/regolith/sway

--- a/usr/bin/regolith-session-wayland
+++ b/usr/bin/regolith-session-wayland
@@ -9,6 +9,7 @@ resolve_default_config_file
 
 load_standard_trawlres
 load_regolith_trawlres
+trawl_sway_cleanup
 
 # Register with gnome-session so that it does not kill the whole session thinking it is dead.
 if [ -n "$DESKTOP_AUTOSTART_ID" ]; then


### PR DESCRIPTION
`regolith-session-flashback` and `regolith-session-sway` have several common files. Trying to install both packages end in an error from `dpkg` saying
```
trying to overwrite '/usr/bin/regolith-diagnostic', which is also in package regolith-session-flashback
```
This PR moves common files required by both sessions into the package `regolith-session-common` in order to fix this issue.