### PR TITLE
Package fix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+regolith-session (0.7.2) focal; urgency=medium
+
+  [ Ken Gilmer ]
+  * Update package metadata, attempt fix of regolith-diagnostic confict
+
+ -- Regolith Linux <regolith.linux@gmail.com>  Sun, 25 Dec 2022 17:29:57 -0800
+
 regolith-session (0.7.1) focal; urgency=medium
 
   * Updated depends for regolith-session-sway

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Depends: ${misc:Depends},
     gnome-session-bin,
     mutter-common,
     regolith-i3-config,
-    regolith-session-common,
+    regolith-session-common (>= 0.7.1),
     x11-xserver-utils,
     regolith-look-default | regolith-look-2,
     xorg,
@@ -73,6 +73,6 @@ Package: regolith-session-common
 Architecture: any
 Depends: ${misc:Depends},
     regolith-resource-loader
-Conflicts: session-shortcuts, regolith-session-flashback (<= 0.6.4-1regolith)
+Conflicts: session-shortcuts, regolith-session-flashback (<= 0.6.4)
 Description: Regolith customized SwayWM session
  This package contains common scripts required by regolith-session variants.


### PR DESCRIPTION
This update intends to fix the following error when adding `experimental` repo and installing `regolith-session-sway`:

```
dpkg: error processing archive /tmp/apt-dpkg-install-5SElUP/39-regolith-session-common_0.7.1-1regolith_amd64.deb (--unpack):
 trying to overwrite '/usr/bin/regolith-diagnostic', which is also in package regolith-session-flashback 0.6.5-1regolith
```
