### PR TITLE
Use quilt packaging format in hopes of resolving build error

### DIFF
--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)


### PR DESCRIPTION
dpkg-source: error: can't build with source format '3.0 (native)': native package version may not have a revision