### PR TITLE
Add dependency on gnome-session-flashback

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Architecture: any
 Depends: ${misc:Depends},
     dbus,
     gnome-flashback,
+    gnome-session-flashback,
     gnome-session-bin,
     mutter-common,
     regolith-i3-root-config,


### PR DESCRIPTION
Including this package to add:
`/etc/xdg/autostart/gnome-flashback-idle-monitor.desktop`

Ref:
https://github.com/orgs/regolith-linux/discussions/804#discussioncomment-5248198