### PR TITLE
use regolith3 for user config directory due to MVB

### DIFF
--- a/usr/bin/regolith-diagnostic
+++ b/usr/bin/regolith-diagnostic
@@ -22,8 +22,8 @@ print_file /etc/lsb-release
 
 echo "--- Xresources"
 print_file "$HOME/.Xresources"
-print_file "$HOME/.config/regolith2/Xresources"
-print_file "$HOME/.cache/regolith2/Xresources-generated"
+print_file "$HOME/.config/regolith3/Xresources"
+print_file "$HOME/.cache/regolith3/Xresources-generated"
 
 if [ $XDG_SESSION_TYPE == "wayland" ]; then
   trawldb -q

--- a/usr/bin/regolith-session-init
+++ b/usr/bin/regolith-session-init
@@ -8,7 +8,7 @@ source /usr/lib/regolith/regolith-session-common.sh
 # --------- Script Main -----------
 
 load_standard_xres  # ~/.Xresources
-load_regolith_xres  # ~/.config/regolith2/Xresources
+load_regolith_xres  # ~/.config/regolith3/Xresources
 
 # Register with gnome-session so that it does not kill the whole session thinking it is dead.
 # See https://zork.net/~st/jottings/gnome-i3.html for details

--- a/usr/lib/regolith/regolith-session-common.sh
+++ b/usr/lib/regolith/regolith-session-common.sh
@@ -2,27 +2,27 @@
 # This script contains common functions for Regolith session management
 
 # File Locations - Optional User Overrides
-USER_XRESOURCE_OVERRIDE_FILE="$HOME/.config/regolith2/Xresources"
-USER_XRESOURCE_SEARCH_PATH="$HOME/.config/regolith2/Xresources.d"
+USER_XRESOURCE_OVERRIDE_FILE="$HOME/.config/regolith3/Xresources"
+USER_XRESOURCE_SEARCH_PATH="$HOME/.config/regolith3/Xresources.d"
 
 # File Locations - System Defaults
 DEFAULT_XRESOURCE_LOOK_PATH="/usr/share/regolith-look/default"
 
 DEFAULT_SYS_I3_CONFIG_FILE="/etc/regolith/i3/config"
-DEFAULT_USER_I3_CONFIG_FILE="$HOME/.config/regolith2/i3/config"
+DEFAULT_USER_I3_CONFIG_FILE="$HOME/.config/regolith3/i3/config"
 
 DEFAULT_SYS_SWAY_CONFIG_FILE="/etc/regolith/sway/config"
-DEFAULT_USER_SWAY_CONFIG_FILE="$HOME/.config/regolith2/sway/config"
+DEFAULT_USER_SWAY_CONFIG_FILE="$HOME/.config/regolith3/sway/config"
 
 # File Locations - Baseline
 BASELINE_XRESOURCE_FILE="$HOME/.Xresources"
 
 # Regolith Look directories
 DEFAULT_LOOK_ROOT="/usr/share/regolith-look"
-USER_LOOK_ROOT="$HOME/.config/regolith2/looks"
+USER_LOOK_ROOT="$HOME/.config/regolith3/looks"
 
 # File location - user scripts
-USER_POST_LOGOUT_SCRIPT_FILE="$HOME/.config/regolith2/logout"
+USER_POST_LOGOUT_SCRIPT_FILE="$HOME/.config/regolith3/logout"
 
 DEFAULT_SESSION_TYPE="i3"
 


### PR DESCRIPTION
This change simply replaces "regoligh2" with "regolith3" for code that references user config dir.