### PR TITLE
Feat direct theme load

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+regolith-session (0.9.0) focal; urgency=medium
+
+  * feat: if a look is not set in xres/trawl, load the most recently installed look instead of default
+
+ -- Regolith Linux <regolith.linux@gmail.com>  Sun, 13 Aug 2023 17:14:40 -0700
+
+regolith-session (0.8.2) focal; urgency=medium
+
+  * fix: push regolith-default-settings down to x11 session, possibly unneeded for wayland (experimental)
+
+ -- Regolith Linux <regolith.linux@gmail.com>  Sun, 13 Aug 2023 12:48:03 -0700
+
 regolith-session (0.8.1) focal; urgency=medium
 
   * feat: add additional diagnostic infor about the current session

--- a/usr/lib/regolith/regolith-session-common.sh
+++ b/usr/lib/regolith/regolith-session-common.sh
@@ -84,6 +84,12 @@ load_regolith_xres() {
         xrdb -I"$USER_XRESOURCE_SEARCH_PATH" -merge "$USER_XRESOURCE_OVERRIDE_FILE"
     fi
 
+    MOST_RECENT_LOOK=$(ls -td /usr/share/regolith-look/* | head -n 1)
+
+    if [ -d "$MOST_RECENT_LOOK" ]; then
+        DEFAULT_XRESOURCE_LOOK_PATH="$MOST_RECENT_LOOK"
+    fi
+
     LOOK_STYLE_ROOT_PATH=$(xrescat regolith.look.path "$DEFAULT_XRESOURCE_LOOK_PATH")
     LOOK_STYLE_ROOT_FILE="$LOOK_STYLE_ROOT_PATH/root"
 
@@ -101,6 +107,12 @@ load_regolith_xres() {
 load_regolith_trawlres() {
     if [ -f "$USER_XRESOURCE_OVERRIDE_FILE" ]; then
         trawldb -I "$USER_XRESOURCE_SEARCH_PATH" --merge "$USER_XRESOURCE_OVERRIDE_FILE"
+    fi
+
+    MOST_RECENT_LOOK=$(ls -td /usr/share/regolith-look/* | head -n 1)
+
+    if [ -d "$MOST_RECENT_LOOK" ]; then
+        DEFAULT_XRESOURCE_LOOK_PATH="$MOST_RECENT_LOOK"
     fi
 
     LOOK_STYLE_ROOT_PATH=$(trawlcat regolith.look.path "$DEFAULT_XRESOURCE_LOOK_PATH")

--- a/usr/lib/regolith/regolith-session-common.sh
+++ b/usr/lib/regolith/regolith-session-common.sh
@@ -91,11 +91,16 @@ load_regolith_xres() {
     fi
 
     LOOK_STYLE_ROOT_PATH=$(xrescat regolith.look.path "$DEFAULT_XRESOURCE_LOOK_PATH")
-    LOOK_STYLE_ROOT_FILE="$LOOK_STYLE_ROOT_PATH/root"
+
+    if [ -d "$LOOK_STYLE_ROOT_PATH" ]; then
+        LOOK_STYLE_ROOT_FILE="$LOOK_STYLE_ROOT_PATH/root"
+    else 
+        LOOK_STYLE_ROOT_FILE="$DEFAULT_XRESOURCE_LOOK_PATH/root"
+    fi
 
     if [ -e "$LOOK_STYLE_ROOT_FILE" ]; then
         xrdb -I"$USER_XRESOURCE_SEARCH_PATH" -merge "$LOOK_STYLE_ROOT_FILE"
-    fi
+    fi #TODO: emit some dialog notifying user of invalid configuration on else
 
     if [ -e "$USER_XRESOURCE_OVERRIDE_FILE" ]; then
         xrdb -I"$USER_XRESOURCE_SEARCH_PATH" -merge "$USER_XRESOURCE_OVERRIDE_FILE"
@@ -116,11 +121,16 @@ load_regolith_trawlres() {
     fi
 
     LOOK_STYLE_ROOT_PATH=$(trawlcat regolith.look.path "$DEFAULT_XRESOURCE_LOOK_PATH")
-    LOOK_STYLE_ROOT_FILE="$LOOK_STYLE_ROOT_PATH/root"
+
+    if [ -d "$LOOK_STYLE_ROOT_PATH" ]; then
+        LOOK_STYLE_ROOT_FILE="$LOOK_STYLE_ROOT_PATH/root"
+    else 
+        LOOK_STYLE_ROOT_FILE="$DEFAULT_XRESOURCE_LOOK_PATH/root"
+    fi
 
     if [ -f "$LOOK_STYLE_ROOT_FILE" ]; then
         trawldb -I "$USER_XRESOURCE_SEARCH_PATH" --merge "$LOOK_STYLE_ROOT_FILE" 
-    fi
+    fi #TODO: emit some dialog notifying user of invalid configuration on else
     
     if [ -f "$USER_XRESOURCE_OVERRIDE_FILE" ]; then
         trawldb -I "$USER_XRESOURCE_SEARCH_PATH" --merge "$USER_XRESOURCE_OVERRIDE_FILE"


### PR DESCRIPTION
In Regolith 2 the default look was paired way down to avoid dependencies as much as possible.  So, no nice fonts or gtk themes.  The idea being that most people would install some other look.  However, this look selection must occur manually after the user has installed, rebooted, and logged into the session.  First impressions are important and that the default look is rather ugly may turn people off.

This change updates the logic of determining which look to load in the case that one hasn't been set by Xres/trawl (this occurs when running the command to set the look or using the dialog).  Rather than defaulting to a hardcoded path, this looks for the most recent directory in the looks and selects it.  Again this behavior only occurs if a user has not specified a look.

base case: only default look installed.  no expected change in behavior
installation case: if user installs a look at the time of regolith desktop install, the non-default look should occur later, and be loaded at first session
look removed case: the session loading executes and finds the most recent directory upon each session create.  There should be no issue
no looks case: broken before, broken after
invalid path in Xres/trawl key for look path: in this PR check to see that path is valid and fall back to default 