### PR TITLE
fix: on first lanch of sway session, call load_look() function to set env

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+regolith-session (0.9.0ubuntu1) UNRELEASED; urgency=medium
+
+  * add error handling in case that Xres/trawl look path is invalid
+  * fix: on first lanch of sway session, call load_look() function to setup environment
+
+ -- Regolith Linux <regolith.linux@gmail.com>  Sun, 13 Aug 2023 18:52:29 -0700
+
 regolith-session (0.9.0) focal; urgency=medium
 
   * feat: if a look is not set in xres/trawl, load the most recently installed look instead of default

--- a/usr/bin/regolith-look
+++ b/usr/bin/regolith-look
@@ -48,12 +48,10 @@ refresh() {
 
     # Determine if Look loader script is available
     LOADER_PATH="$($RESOURCE_GETTER regolith.look.loader)"
-    echo "Loader Path: $LOADER_PATH"
     if [ -n  "$LOADER_PATH" ]; then
         # Load the look-specific script that has a function called load_look()
         source "$LOADER_PATH"
         # Call look function to update UI
-        echo "Executing look loader script: $LOADER_PATH"
         load_look
 
         # restart window manager after merging Xresources

--- a/usr/bin/regolith-session-wayland
+++ b/usr/bin/regolith-session-wayland
@@ -18,11 +18,23 @@ load_regolith_trawlres
 
 trawl_sway_cleanup
 
+UPDATE_FLAG_DIR="$HOME/.config/regolith3/flags"
+if [ ! -e "$UPDATE_FLAG_DIR" ]; then
+    # flag file has not been created, meaning this is first session load
+    # in this case, we need to configure some desktop settings from the look
+    LOADER_PATH="$($RESOURCE_GETTER regolith.look.loader)"
+    if [ -n  "$LOADER_PATH" ]; then
+        # Load the look-specific script that has a function called load_look()
+        source "$LOADER_PATH"
+        # Call look function to update UI
+        load_look
+    fi
+fi
+
 # Register with gnome-session so that it does not kill the whole session thinking it is dead.
 if [ -n "$DESKTOP_AUTOSTART_ID" ]; then
     dbus-send --print-reply --session --dest=org.gnome.SessionManager "/org/gnome/SessionManager" org.gnome.SessionManager.RegisterClient "string:Regolith" "string:$DESKTOP_AUTOSTART_ID"
 fi
-
 
 # Import environment variables from environment.d
 while read -r l; do


### PR DESCRIPTION
This change is a substitute for the package `regolith-default-settings` on X11.  In X11, that package configures some gsettings dconf values for the user before they log in.  Since most of this stuff isn't necessary for sway, rather than having an alternate package, have the look get set on first session load.