### PR TITLE
fix: dont start session service starting targets

### DIFF
--- a/usr/lib/systemd/user/gnome-session@regolith-wayland.target.d/session.conf
+++ b/usr/lib/systemd/user/gnome-session@regolith-wayland.target.d/session.conf
@@ -9,4 +9,4 @@ Wants=org.gnome.SettingsDaemon.Smartcard.target
 Wants=org.gnome.SettingsDaemon.Sound.target
 Wants=org.gnome.SettingsDaemon.Rfkill.target
 
-Requires=regolith-wayland.target
+Requires=regolith-wayland.service

--- a/usr/lib/systemd/user/gnome-session@regolith-x11.target.d/session.conf
+++ b/usr/lib/systemd/user/gnome-session@regolith-x11.target.d/session.conf
@@ -16,4 +16,4 @@ Wants=org.gnome.SettingsDaemon.Wacom.target
 Wants=org.gnome.SettingsDaemon.XSettings.target
 Wants=gnome-flashback.target
 
-Requires=regolith-x11.target
+Requires=regolith-x11.service

--- a/usr/lib/systemd/user/regolith-wayland.service
+++ b/usr/lib/systemd/user/regolith-wayland.service
@@ -13,6 +13,10 @@ Requisite=gnome-session-initialized.target
 PartOf=gnome-session-initialized.target
 Before=gnome-session-initialized.target
 
+PartOf=regolith-wayland.target
+BindsTo=regolith-wayland.target
+After=regolith-wayland.target
+
 Requires=trawld.service
 
 ConditionEnvironment=XDG_SESSION_TYPE=wayland

--- a/usr/lib/systemd/user/regolith-wayland.target
+++ b/usr/lib/systemd/user/regolith-wayland.target
@@ -5,5 +5,3 @@ DefaultDependencies=no
 Requisite=gnome-session-initialized.target
 PartOf=gnome-session-initialized.target
 Before=gnome-session-initialized.target
-
-Wants=regolith-wayland.service

--- a/usr/lib/systemd/user/regolith-x11.service
+++ b/usr/lib/systemd/user/regolith-x11.service
@@ -13,6 +13,10 @@ Requisite=gnome-session-initialized.target
 PartOf=gnome-session-initialized.target
 Before=gnome-session-initialized.target
 
+PartOf=regolith-x11.target
+BindsTo=regolith-x11.target
+After=regolith-x11.target
+
 ConditionEnvironment=XDG_SESSION_TYPE=x11
 
 # Limit startup frequency more than the default

--- a/usr/lib/systemd/user/regolith-x11.target
+++ b/usr/lib/systemd/user/regolith-x11.target
@@ -5,5 +5,3 @@ DefaultDependencies=no
 Requisite=gnome-session-initialized.target
 PartOf=gnome-session-initialized.target
 Before=gnome-session-initialized.target
-
-Wants=regolith-x11.service


### PR DESCRIPTION
This commit ensures that starting regolith-wayland.target and regolith-x11.target doesn't automatically start their corresponding services. However, the targets are still started with their corresponding services, for which regolith-x11.service and regolith-wayland.service are made into the entry points for the session.

These changes also establish a stronger dependency between service files and target files using the `BindsTo` directive, such that the lifecycle of regolith-wayland.service and regolith-x11.service is dependent on regolith-wayland.target and regolith-x11.target. This implies, starting the services starts the targets and the service then responds to lifecycle of the target, including restart and stop. But starting the target won't start the service.

Fixes: #36