### PR TITLE
chore: bump changelog dedicated version per branch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+regolith-session (1.1.13-3) jammy; urgency=medium
+
+  * UNRELEASED
+
+ -- Regolith Linux <regolith.linux@gmail.com>  Mon, 10 Feb 2025 12:27:46 -0500
+
 regolith-session (1.1.12-4) jammy; urgency=medium
 
   * UNRELEASED


### PR DESCRIPTION
This repository has multiple "live branches." It means we are publishing packages from different branches to archive repositories and as such we have to have different versions per branch.

The approach we take is to append a suffix to the version per live branch. For example:

- `x.y.z-1`: is for `main` branch
- `x.y.z-2`: is for `debian-trixie` branch (to be created)
- `x.y.z-3`: is for `debian-bookworm` branch

Note that we can keep the actual version (i.e. `x.y.z`) the same, or if needs be they can be on completely different version.