### PR TITLE
feat: sway-audio-idle-inhibit as recommends dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -67,6 +67,7 @@ Depends: ${misc:Depends},
     wl-clipboard,
     xwayland
 Recommends:
+    sway-audio-idle-inhibit,
     gnome-terminal,
     regolith-wm-rofication-ilia,
     xdg-desktop-portal-regolith-wayland-config


### PR DESCRIPTION
The  `regolith-sway-audio-idle-inhibit` package will be removed in https://github.com/regolith-linux/regolith-wm-config/pull/57. 

To retain functionality, this PR adds the `sway-audio-idle-inhibit` package as a dependency to the `regolith-sway-session`.