### PR TITLE
chore: properly depricate regolith-sway-audio-idle-inhibit

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -67,12 +67,14 @@ Depends: ${misc:Depends},
     wl-clipboard,
     xwayland
 Recommends:
-    sway-audio-idle-inhibit,
+    sway-audio-idle-inhibit (>= 2.0.0),
     gnome-terminal,
     regolith-wm-rofication-ilia,
     xdg-desktop-portal-regolith-wayland-config
 Provides: regolith-desktop-session
 Conflicts: session-shortcuts
+Breaks: regolith-sway-audio-idle-inhibit
+Replaces: regolith-sway-audio-idle-inhibit
 Description: Regolith customized SwayWM session
  This package contains the desktop and wayland session configuration
  necessary to start a Regolith sway session.


### PR DESCRIPTION
In order to make sure updating to the latest `regolith-session` package removes the deprecated `regolith-sway-audio-idle-inhibit`, added `Breaks` and `Replaces` directives. Also specified the minimum version of `sway-audio-idle-inhibit` package required to ensure the systemd service is available.