### PR TITLE
fix: add missing i3-wm dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Vcs-Git: https://github.com/regolith-linux/regolith-desktop.git
 Package: regolith-session-flashback
 Architecture: any
 Depends: ${misc:Depends},
+    i3-wm,
     dbus,
     gnome-flashback,
     gnome-session-bin,


### PR DESCRIPTION
`control` was missing a dependency on `i3-wm` for the `regolith-session-flashback`. 